### PR TITLE
Add support for multi-line imports

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -15,5 +15,6 @@
         "tsyringe",
         "utest",
         "pubspec"
-    ]
+    ],
+    "editor.formatOnSave": true,
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,12 @@
 {
     "name": "dart-import-sorter",
-    "version": "0.2.7",
+    "version": "0.2.10",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
-            "version": "0.2.7",
+            "name": "dart-import-sorter",
+            "version": "0.2.10",
             "dependencies": {
                 "reflect-metadata": "^0.1.13",
                 "tsyringe": "^4.6.0"

--- a/src/app/import-sorter/import-sorter.impl.test.ts
+++ b/src/app/import-sorter/import-sorter.impl.test.ts
@@ -141,7 +141,7 @@ describe('', () => {
     test('Groups imports correctly with default settings', () => {
         const sortingResult = importSorter.sortImports(DEFAULT_MESSY_IMPORTS);
 
-        expect(sortingResult.firstRawImportIndex).toBe(1);
+        expect(sortingResult.firstRawImportIndex).toBe(2);
         expect(sortingResult.lastRawImportIndex).toBe(47);
         expect(sortingResult.sortedImports).toBe(DEFAULT_SORTED_IMPORTS);
     });
@@ -152,7 +152,7 @@ describe('', () => {
 
         const sortingResult = importSorter.sortImports(DEFAULT_MESSY_IMPORTS);
 
-        expect(sortingResult.firstRawImportIndex).toBe(1);
+        expect(sortingResult.firstRawImportIndex).toBe(2);
         expect(sortingResult.lastRawImportIndex).toBe(47);
         expect(sortingResult.sortedImports).toBe(DEFAULT_SORTED_IMPORTS);
     });
@@ -163,8 +163,8 @@ describe('', () => {
 
         const messyImports = `import 'viewmodel.dart';
 import 'dart:async';
-import package:flutter/material.dart;
-import package:gym_app/constants;
+import 'package:flutter/material.dart';
+import 'package:gym_app/constants';
 
 
 
@@ -173,18 +173,18 @@ import 'dart:math';
 import '../beyond/foo/something.dart';
 `;
 
-        const sortedImports = `import 'dart:async';
+        const expectedSortedImports = `import 'dart:async';
 import 'dart:math';
-import package:flutter/material.dart;
-import package:gym_app/constants;
+import 'package:flutter/material.dart';
+import 'package:gym_app/constants';
 import '../beyond/foo/something.dart';
 import 'viewmodel.dart';`;
 
         const sortingResult = importSorter.sortImports(messyImports);
 
-        expect(sortingResult.firstRawImportIndex).toBe(0);
+        expect(sortingResult.firstRawImportIndex).toBe(1);
         expect(sortingResult.lastRawImportIndex).toBe(10);
-        expect(sortingResult.sortedImports).toBe(sortedImports);
+        expect(sortingResult.sortedImports).toBe(expectedSortedImports);
     });
 
     test('Return no result when there are no imports to sort', () => {

--- a/src/app/import-sorter/import-sorter.impl.test.ts
+++ b/src/app/import-sorter/import-sorter.impl.test.ts
@@ -101,7 +101,7 @@ import 'home_viewmodel.dart';
 import 'path/to/my_other_file.dart';`;
 
 const DEFAULT_SETTINGS: IExtensionSettings = {
-    leaveEmptyLinesBetweenImports: true,
+    leaveEmptyLinesBetweenImports: false,
     sortOnSaveEnabled: false,
     sortingRules: [
         {
@@ -138,7 +138,10 @@ describe('', () => {
         importSorter = new ImportSorter(settings);
     });
 
-    test('Groups imports correctly with default settings', () => {
+    test('Groups imports correctly with default settings, but with line breaks enabled', () => {
+        settings = { ...settings, leaveEmptyLinesBetweenImports: true };
+        importSorter = new ImportSorter(settings);
+
         const sortingResult = importSorter.sortImports(DEFAULT_MESSY_IMPORTS);
 
         expect(sortingResult.firstRawImportIndex).toBe(2);
@@ -186,6 +189,143 @@ import 'viewmodel.dart';`;
         expect(sortingResult.lastRawImportIndex).toBe(10);
         expect(sortingResult.sortedImports).toBe(expectedSortedImports);
     });
+
+    test('Sorts a basic list of consecutive imports', () => {
+        const messyImports = `import 'viewmodel.dart';
+import 'dart:async';
+import 'package:flutter/material.dart';
+import 'package:gym_app/constants';
+import 'dart:math';
+import '../beyond/foo/something.dart';
+`;
+
+        const expectedSortedImports = `import 'dart:async';
+import 'dart:math';
+import 'package:flutter/material.dart';
+import 'package:gym_app/constants';
+import '../beyond/foo/something.dart';
+import 'viewmodel.dart';`;
+
+        const sortingResult = importSorter.sortImports(messyImports);
+
+        expect(sortingResult.firstRawImportIndex).toBe(1);
+        expect(sortingResult.lastRawImportIndex).toBe(6);
+        expect(sortingResult.sortedImports).toBe(expectedSortedImports);
+
+        // Sorting again should not change anything
+        const sortingResult2 = importSorter.sortImports(sortingResult.sortedImports);
+
+        expect(sortingResult2.firstRawImportIndex).toBe(1);
+        expect(sortingResult2.lastRawImportIndex).toBe(6);
+
+        expect(sortingResult2.sortedImports).toBe(expectedSortedImports);
+    });
+
+    test('Sorts a list of consecutive imports, with line breaks', () => {
+        const messyImports = `import 'viewmodel.dart';
+import 'dart:async';
+
+
+
+
+
+
+
+
+
+
+import 'package:flutter/material.dart';
+import 'package:gym_app/constants';
+
+
+import 'dart:math';
+
+import '../beyond/foo/something.dart';
+`;
+
+        const expectedSortedImports = `import 'dart:async';
+import 'dart:math';
+import 'package:flutter/material.dart';
+import 'package:gym_app/constants';
+import '../beyond/foo/something.dart';
+import 'viewmodel.dart';`;
+
+        const sortingResult = importSorter.sortImports(messyImports);
+
+        expect(sortingResult.firstRawImportIndex).toBe(1);
+        expect(sortingResult.lastRawImportIndex).toBe(19);
+        expect(sortingResult.sortedImports).toBe(expectedSortedImports);
+
+        // Sorting again should not change anything (but last index is now 6 because line breaks were removed in the first sort)
+        const sortingResult2 = importSorter.sortImports(sortingResult.sortedImports);
+
+        expect(sortingResult2.firstRawImportIndex).toBe(1);
+        expect(sortingResult2.lastRawImportIndex).toBe(6);
+
+        expect(sortingResult2.sortedImports).toBe(expectedSortedImports);
+    });
+
+    // FIXME
+    test('Sorts a list of consecutive imports, with comments (especially the last import)', () => {
+        const messyImports = `// I was the first import
+import 'viewmodel.dart';
+// I was the second import
+import 'dart:async';
+// I was the third import
+import 'package:flutter/material.dart';
+// I was the fourth import
+import 'package:gym_app/constants';
+// I was the fifth import
+import 'dart:math';
+// I was the sixth import
+import '../beyond/foo/something.dart';
+`;
+
+        const expectedSortedImports = `// I was the second import
+import 'dart:async';
+// I was the fifth import
+import 'dart:math';
+// I was the third import
+import 'package:flutter/material.dart';
+// I was the fourth import
+import 'package:gym_app/constants';
+// I was the sixth import
+import '../beyond/foo/something.dart';
+// I was the first import
+import 'viewmodel.dart';`;
+
+        console.log(messyImports);
+        console.log(expectedSortedImports);
+
+        const sortingResult = importSorter.sortImports(messyImports);
+
+        expect(sortingResult.firstRawImportIndex).toBe(1);
+        expect(sortingResult.lastRawImportIndex).toBe(12);
+        expect(sortingResult.sortedImports).toBe(expectedSortedImports);
+
+        // Sorting again should not change anything
+        const sortingResult2 = importSorter.sortImports(sortingResult.sortedImports);
+
+        expect(sortingResult2.firstRawImportIndex).toBe(1);
+        expect(sortingResult2.lastRawImportIndex).toBe(12);
+
+        expect(sortingResult2.sortedImports).toBe(expectedSortedImports);
+    });
+
+    // TODO
+    test('Sorts a list of imports, with comments and line breaks', () => {});
+
+    // TODO
+    test('Sorts a consecutive list of imports, with annotations', () => {});
+
+    // TODO
+    test('Sorts a list of imports, with annotations and line breaks', () => {});
+
+    // TODO
+    test('Sorts a list of imports, with comments and annotations', () => {});
+
+    // TODO
+    test('Sorts a list of imports, with comments, annotations, and line breaks', () => {});
 
     test('Return no result when there are no imports to sort', () => {
         const sortingResult = importSorter.sortImports('');

--- a/src/app/import-sorter/import-sorter.impl.test.ts
+++ b/src/app/import-sorter/import-sorter.impl.test.ts
@@ -160,7 +160,7 @@ describe('', () => {
         expect(sortingResult.sortedImports).toBe(DEFAULT_SORTED_IMPORTS);
     });
 
-    test("Doesn't leave new lines between groups", () => {
+    test('Does not leave new lines between groups', () => {
         settings = { ...settings, leaveEmptyLinesBetweenImports: false };
         importSorter = new ImportSorter(settings);
 
@@ -555,6 +555,165 @@ import 'viewmodel.dart';`;
 
         expect(sortingResult2.firstRawImportIndex).toBe(1);
         expect(sortingResult2.lastRawImportIndex).toBe(16);
+
+        expect(sortingResult2.sortedImports).toBe(expectedSortedImports);
+    });
+
+    test('Sorts a list of multiline conditional imports with comments, annotations, and line breaks', () => {
+        const messyImports = `// I was the first import
+@deprecated
+import 'viewmodel.dart';
+
+
+// I was the second import
+@deprecated
+import 'dart:async';
+// I was the third import
+import 'package:flutter/material.dart';
+
+// This is a multiline conditional import
+@deprecated
+import 'package:gym_app/constants'
+    if (dart.library.io) 'package:gym_app/constants_io'
+    if (dart.library.html) 'package:gym_app/constants_web';
+// This is also a multiline conditional import
+@deprecated
+import 'package:gym_app/various'
+    if (dart.library.io) 'package:gym_app/various_io'
+    if (dart.library.html) 'package:gym_app/various_web';
+
+// I was the fourth import
+@deprecated
+import 'package:gym_app/constants';
+
+// I was the fifth import
+import 'dart:math';
+// I was the sixth import
+@deprecated
+import '../beyond/foo/something.dart';
+`;
+
+        const expectedSortedImports = `// I was the second import
+@deprecated
+import 'dart:async';
+// I was the fifth import
+import 'dart:math';
+// I was the third import
+import 'package:flutter/material.dart';
+// This is a multiline conditional import
+@deprecated
+import 'package:gym_app/constants'
+    if (dart.library.io) 'package:gym_app/constants_io'
+    if (dart.library.html) 'package:gym_app/constants_web';
+// I was the fourth import
+@deprecated
+import 'package:gym_app/constants';
+// This is also a multiline conditional import
+@deprecated
+import 'package:gym_app/various'
+    if (dart.library.io) 'package:gym_app/various_io'
+    if (dart.library.html) 'package:gym_app/various_web';
+// I was the sixth import
+@deprecated
+import '../beyond/foo/something.dart';
+// I was the first import
+@deprecated
+import 'viewmodel.dart';`;
+
+        const sortingResult = importSorter.sortImports(messyImports);
+
+        expect(sortingResult.firstRawImportIndex).toBe(1);
+        expect(sortingResult.lastRawImportIndex).toBe(31);
+        expect(sortingResult.sortedImports).toBe(expectedSortedImports);
+
+        // Sorting again should not change anything
+        const sortingResult2 = importSorter.sortImports(sortingResult.sortedImports);
+
+        expect(sortingResult2.firstRawImportIndex).toBe(1);
+        expect(sortingResult2.lastRawImportIndex).toBe(26);
+
+        expect(sortingResult2.sortedImports).toBe(expectedSortedImports);
+    });
+
+    test('Sorts a list of multiline conditional imports with comments, annotations, and line breaks, with emptyLinesBetweenGroups enabled', () => {
+        settings = { ...settings, leaveEmptyLinesBetweenImports: true };
+        importSorter = new ImportSorter(settings);
+
+        const messyImports = `// I was the first import
+@deprecated
+import 'viewmodel.dart';
+
+
+// I was the second import
+@deprecated
+import 'dart:async';
+// I was the third import
+import 'package:flutter/material.dart';
+
+// This is a multiline conditional import
+@deprecated
+import 'package:gym_app/constants'
+    if (dart.library.io) 'package:gym_app/constants_io'
+    if (dart.library.html) 'package:gym_app/constants_web';
+// This is also a multiline conditional import
+@deprecated
+import 'package:gym_app/various'
+    if (dart.library.io) 'package:gym_app/various_io'
+    if (dart.library.html) 'package:gym_app/various_web';
+
+// I was the fourth import
+@deprecated
+import 'package:gym_app/constants';
+
+// I was the fifth import
+import 'dart:math';
+// I was the sixth import
+@deprecated
+import '../beyond/foo/something.dart';
+`;
+
+        const expectedSortedImports = `// I was the second import
+@deprecated
+import 'dart:async';
+// I was the fifth import
+import 'dart:math';
+
+// I was the third import
+import 'package:flutter/material.dart';
+
+// This is a multiline conditional import
+@deprecated
+import 'package:gym_app/constants'
+    if (dart.library.io) 'package:gym_app/constants_io'
+    if (dart.library.html) 'package:gym_app/constants_web';
+// I was the fourth import
+@deprecated
+import 'package:gym_app/constants';
+// This is also a multiline conditional import
+@deprecated
+import 'package:gym_app/various'
+    if (dart.library.io) 'package:gym_app/various_io'
+    if (dart.library.html) 'package:gym_app/various_web';
+
+// I was the sixth import
+@deprecated
+import '../beyond/foo/something.dart';
+
+// I was the first import
+@deprecated
+import 'viewmodel.dart';`;
+
+        const sortingResult = importSorter.sortImports(messyImports);
+
+        expect(sortingResult.firstRawImportIndex).toBe(1);
+        expect(sortingResult.lastRawImportIndex).toBe(31);
+        expect(sortingResult.sortedImports).toBe(expectedSortedImports);
+
+        // Sorting again should not change anything
+        const sortingResult2 = importSorter.sortImports(sortingResult.sortedImports);
+
+        expect(sortingResult2.firstRawImportIndex).toBe(1);
+        expect(sortingResult2.lastRawImportIndex).toBe(30);
 
         expect(sortingResult2.sortedImports).toBe(expectedSortedImports);
     });

--- a/src/app/import-sorter/import-sorter.impl.test.ts
+++ b/src/app/import-sorter/import-sorter.impl.test.ts
@@ -265,7 +265,6 @@ import 'viewmodel.dart';`;
         expect(sortingResult2.sortedImports).toBe(expectedSortedImports);
     });
 
-    // FIXME
     test('Sorts a list of consecutive imports, with comments (especially the last import)', () => {
         const messyImports = `// I was the first import
 import 'viewmodel.dart';
@@ -294,8 +293,99 @@ import '../beyond/foo/something.dart';
 // I was the first import
 import 'viewmodel.dart';`;
 
-        console.log(messyImports);
-        console.log(expectedSortedImports);
+        const sortingResult = importSorter.sortImports(messyImports);
+
+        expect(sortingResult.firstRawImportIndex).toBe(1);
+        expect(sortingResult.lastRawImportIndex).toBe(12);
+        expect(sortingResult.sortedImports).toBe(expectedSortedImports);
+
+        // Sorting again should not change anything
+        const sortingResult2 = importSorter.sortImports(sortingResult.sortedImports);
+
+        expect(sortingResult2.firstRawImportIndex).toBe(1);
+        expect(sortingResult2.lastRawImportIndex).toBe(12);
+
+        expect(sortingResult2.sortedImports).toBe(expectedSortedImports);
+    });
+
+    test('Sorts a list of imports, with comments and line breaks', () => {
+        const messyImports = `// I was the first import
+import 'viewmodel.dart';
+
+// I was the second import
+import 'dart:async';
+
+
+
+
+
+// I was the third import
+import 'package:flutter/material.dart';
+// I was the fourth import
+import 'package:gym_app/constants';
+
+// I was the fifth import
+import 'dart:math';
+
+// I was the sixth import
+import '../beyond/foo/something.dart';
+`;
+
+        const expectedSortedImports = `// I was the second import
+import 'dart:async';
+// I was the fifth import
+import 'dart:math';
+// I was the third import
+import 'package:flutter/material.dart';
+// I was the fourth import
+import 'package:gym_app/constants';
+// I was the sixth import
+import '../beyond/foo/something.dart';
+// I was the first import
+import 'viewmodel.dart';`;
+
+        const sortingResult = importSorter.sortImports(messyImports);
+
+        expect(sortingResult.firstRawImportIndex).toBe(1);
+        expect(sortingResult.lastRawImportIndex).toBe(20);
+        expect(sortingResult.sortedImports).toBe(expectedSortedImports);
+
+        // Sorting again should not change anything
+        const sortingResult2 = importSorter.sortImports(sortingResult.sortedImports);
+
+        expect(sortingResult2.firstRawImportIndex).toBe(1);
+        expect(sortingResult2.lastRawImportIndex).toBe(12);
+
+        expect(sortingResult2.sortedImports).toBe(expectedSortedImports);
+    });
+
+    test('Sorts a consecutive list of imports, with annotations', () => {
+        const messyImports = `@deprecated
+import 'viewmodel.dart';
+@deprecated
+import 'dart:async';
+@deprecated
+import 'package:flutter/material.dart';
+@deprecated
+import 'package:gym_app/constants';
+@deprecated
+import 'dart:math';
+@deprecated
+import '../beyond/foo/something.dart';
+`;
+
+        const expectedSortedImports = `@deprecated
+import 'dart:async';
+@deprecated
+import 'dart:math';
+@deprecated
+import 'package:flutter/material.dart';
+@deprecated
+import 'package:gym_app/constants';
+@deprecated
+import '../beyond/foo/something.dart';
+@deprecated
+import 'viewmodel.dart';`;
 
         const sortingResult = importSorter.sortImports(messyImports);
 
@@ -312,20 +402,162 @@ import 'viewmodel.dart';`;
         expect(sortingResult2.sortedImports).toBe(expectedSortedImports);
     });
 
-    // TODO
-    test('Sorts a list of imports, with comments and line breaks', () => {});
+    test('Sorts a list of imports, with annotations and line breaks', () => {
+        const messyImports = `@deprecated
+import 'viewmodel.dart';
 
-    // TODO
-    test('Sorts a consecutive list of imports, with annotations', () => {});
 
-    // TODO
-    test('Sorts a list of imports, with annotations and line breaks', () => {});
+@deprecated
+import 'dart:async';
 
-    // TODO
-    test('Sorts a list of imports, with comments and annotations', () => {});
+@deprecated
+import 'package:flutter/material.dart';
+@deprecated
+import 'package:gym_app/constants';
 
-    // TODO
-    test('Sorts a list of imports, with comments, annotations, and line breaks', () => {});
+
+@deprecated
+import 'dart:math';
+
+@deprecated
+import '../beyond/foo/something.dart';
+    `;
+
+        const expectedSortedImports = `@deprecated
+import 'dart:async';
+@deprecated
+import 'dart:math';
+@deprecated
+import 'package:flutter/material.dart';
+@deprecated
+import 'package:gym_app/constants';
+@deprecated
+import '../beyond/foo/something.dart';
+@deprecated
+import 'viewmodel.dart';`;
+
+        const sortingResult = importSorter.sortImports(messyImports);
+
+        expect(sortingResult.firstRawImportIndex).toBe(1);
+        expect(sortingResult.lastRawImportIndex).toBe(18);
+        expect(sortingResult.sortedImports).toBe(expectedSortedImports);
+
+        // Sorting again should not change anything
+        const sortingResult2 = importSorter.sortImports(sortingResult.sortedImports);
+
+        expect(sortingResult2.firstRawImportIndex).toBe(1);
+        expect(sortingResult2.lastRawImportIndex).toBe(12);
+
+        expect(sortingResult2.sortedImports).toBe(expectedSortedImports);
+    });
+
+    test('Sorts a list of imports, with comments and annotations', () => {
+        const messyImports = `// I was the first import
+@deprecated
+import 'viewmodel.dart';
+// I was the second import
+@deprecated
+import 'dart:async';
+// I was the third import
+import 'package:flutter/material.dart';
+// I was the fourth import
+@deprecated
+import 'package:gym_app/constants';
+// I was the fifth import
+import 'dart:math';
+// I was the sixth import
+@deprecated
+import '../beyond/foo/something.dart';
+`;
+
+        const expectedSortedImports = `// I was the second import
+@deprecated
+import 'dart:async';
+// I was the fifth import
+import 'dart:math';
+// I was the third import
+import 'package:flutter/material.dart';
+// I was the fourth import
+@deprecated
+import 'package:gym_app/constants';
+// I was the sixth import
+@deprecated
+import '../beyond/foo/something.dart';
+// I was the first import
+@deprecated
+import 'viewmodel.dart';`;
+
+        const sortingResult = importSorter.sortImports(messyImports);
+
+        expect(sortingResult.firstRawImportIndex).toBe(1);
+        expect(sortingResult.lastRawImportIndex).toBe(16);
+        expect(sortingResult.sortedImports).toBe(expectedSortedImports);
+
+        // Sorting again should not change anything
+        const sortingResult2 = importSorter.sortImports(sortingResult.sortedImports);
+
+        expect(sortingResult2.firstRawImportIndex).toBe(1);
+        expect(sortingResult2.lastRawImportIndex).toBe(16);
+
+        expect(sortingResult2.sortedImports).toBe(expectedSortedImports);
+    });
+
+    test('Sorts a list of imports, with comments, annotations, and line breaks', () => {
+        const messyImports = `// I was the first import
+@deprecated
+import 'viewmodel.dart';
+
+
+// I was the second import
+@deprecated
+import 'dart:async';
+// I was the third import
+import 'package:flutter/material.dart';
+
+
+
+// I was the fourth import
+@deprecated
+import 'package:gym_app/constants';
+
+// I was the fifth import
+import 'dart:math';
+// I was the sixth import
+@deprecated
+import '../beyond/foo/something.dart';
+`;
+
+        const expectedSortedImports = `// I was the second import
+@deprecated
+import 'dart:async';
+// I was the fifth import
+import 'dart:math';
+// I was the third import
+import 'package:flutter/material.dart';
+// I was the fourth import
+@deprecated
+import 'package:gym_app/constants';
+// I was the sixth import
+@deprecated
+import '../beyond/foo/something.dart';
+// I was the first import
+@deprecated
+import 'viewmodel.dart';`;
+
+        const sortingResult = importSorter.sortImports(messyImports);
+
+        expect(sortingResult.firstRawImportIndex).toBe(1);
+        expect(sortingResult.lastRawImportIndex).toBe(22);
+        expect(sortingResult.sortedImports).toBe(expectedSortedImports);
+
+        // Sorting again should not change anything
+        const sortingResult2 = importSorter.sortImports(sortingResult.sortedImports);
+
+        expect(sortingResult2.firstRawImportIndex).toBe(1);
+        expect(sortingResult2.lastRawImportIndex).toBe(16);
+
+        expect(sortingResult2.sortedImports).toBe(expectedSortedImports);
+    });
 
     test('Return no result when there are no imports to sort', () => {
         const sortingResult = importSorter.sortImports('');

--- a/src/app/import-utils/import-utils.test.ts
+++ b/src/app/import-utils/import-utils.test.ts
@@ -291,7 +291,7 @@ import 'foo.dart'
     if (dart.library.html) 'src/hw_html.dart';
 `;
 
-        const simplifiedImport = ImportUtils.simplifyMultilineImport(raw);
+        const simplifiedImport = ImportUtils.simplifyImport(raw);
         const expected = `import 'foo.dart' if (dart.library.io) 'src/hw_io.dart' if (dart.library.html) 'src/hw_html.dart';`;
 
         expect(simplifiedImport).toBe(expected);
@@ -308,8 +308,23 @@ import 'foo.dart'
     if (dart.library.html) 'src/hw_html.dart';
 `;
 
-        const simplifiedImport = ImportUtils.simplifyMultilineImport(raw);
+        const simplifiedImport = ImportUtils.simplifyImport(raw);
         const expected = `import 'foo.dart' if (dart.library.io) 'src/hw_io.dart' if (dart.library.html) 'src/hw_html.dart';`;
+
+        expect(simplifiedImport).toBe(expected);
+    });
+
+    test('should simplify a multiline import statement with comments and annotations into a single line', () => {
+        const raw = `
+// This is also a multiline conditional import
+@deprecated
+import 'package:gym_app/various'
+    if (dart.library.io) 'package:gym_app/various_io'
+    if (dart.library.html) 'package:gym_app/various_web';
+`;
+
+        const simplifiedImport = ImportUtils.simplifyImport(raw);
+        const expected = `import 'package:gym_app/various' if (dart.library.io) 'package:gym_app/various_io' if (dart.library.html) 'package:gym_app/various_web';`;
 
         expect(simplifiedImport).toBe(expected);
     });

--- a/src/app/import-utils/import-utils.test.ts
+++ b/src/app/import-utils/import-utils.test.ts
@@ -1,37 +1,44 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+import { ImportStatement } from './../types/import-statement.model';
 import { ImportUtils } from './import-utils';
 
 describe('Import Utils', () => {
     test('should get correct index of first import', () => {
-        const imports = `
+        const imports = [
+            new ImportStatement("import 'bla1';", 99),
+            new ImportStatement("import 'bla2';", 3),
+            new ImportStatement("import 'bla3';", 12),
+            new ImportStatement("import 'bla4';", 6),
+        ];
 
-import 'bla1';
-import 'bla2';
-import 'bla3';
-import 'bla4';`.split('\n');
-
-        expect(ImportUtils.indexOfFirstImport(imports)).toBe(2);
+        expect(ImportUtils.lineNumberOfFirstImport(imports)).toBe(3);
     });
 
     test('should get correct index of last import', () => {
-        const imports = `
+        const imports = [
+            new ImportStatement("import 'bla1';", 99),
+            new ImportStatement("import 'bla2';", 3),
+            new ImportStatement("import 'bla3';", 12),
+            new ImportStatement("import 'bla4';", 6),
+        ];
 
-import 'bla1';
-import 'bla2';
-import 'bla3';
-import 'bla4';`.split('\n');
-
-        expect(ImportUtils.indexOfLastImport(imports)).toBe(6);
-
-        expect(ImportUtils.indexOfLastImport([''])).toBe(0);
+        expect(ImportUtils.lineNumberOfLastImport(imports)).toBe(99);
     });
 
     test('should correctly detect import statements', () => {
         const imports = [
             `import 'something';`,
-            `import 'something' as something_else;`,
             `import 'something/with/a/long/path';`,
-            `import '';`,
+
+            `import 'something' as something_else;`,
             `import 'as' as a_s;`,
+            `import 'as' show Foo;`,
+
+            // single line conditional import
+            `import 'dart.math' if (dart.library.html) 'dart:html';`,
+
+            // simplified multiline conditional import
+            `import 'foo.dart' if (dart.library.io) 'src/hw_io.dart' if (dart.library.html) 'src/hw_html.dart';`,
         ];
 
         imports.forEach((statement) => {
@@ -39,37 +46,378 @@ import 'bla4';`.split('\n');
         });
     });
 
+    test('should detect basic consecutive import statements', () => {
+        const raw = `
+import 'something.dart';
+import 'something.dart' as something_else;
+        `;
+
+        const imports = ImportUtils.findAllImports(raw);
+
+        expect(imports.length).toBe(2);
+
+        // import text should be present
+        expect(imports[0].rawBody).toContain("import 'something.dart';");
+        expect(imports[1].rawBody).toContain("import 'something.dart' as something_else;");
+    });
+
+    test('should detect basic consecutive import statements with a blank lines', () => {
+        const raw = `
+import 'something.dart';
+
+import 'something.dart' as something_else;
+        `;
+
+        const imports = ImportUtils.findAllImports(raw);
+
+        expect(imports.length).toBe(2);
+
+        // import text should be present
+        expect(imports[0].rawBody).toContain("import 'something.dart';");
+        expect(imports[1].rawBody).toContain("import 'something.dart' as something_else;");
+    });
+
+    test('should detect basic import statements with comments', () => {
+        const raw = `
+// this is a comment
+import 'something.dart';
+// this is a comment, too!
+import 'something.dart' as something_else;
+        `;
+
+        const imports = ImportUtils.findAllImports(raw);
+
+        expect(imports.length).toBe(2);
+
+        // both import and comment text should be present
+        expect(imports[0].rawBody).toContain('this is a comment');
+        expect(imports[0].rawBody).toContain("import 'something.dart';");
+
+        expect(imports[1].rawBody).toContain('this is a comment, too!');
+        expect(imports[1].rawBody).toContain("import 'something.dart' as something_else;");
+    });
+
+    test('should detect conditional imports with comments mixed with basic imports', () => {
+        const raw = `
+// this is a comment
+import 'something.dart';
+
+// this is a comment, too!
+import 'something.dart' as something_else;
+
+// This is a conditional import!
+import 'dart.math' if (dart.library.html) 'dart:html';
+
+// this is also a conditional import!
+import 'dart.math' if (dart.library.html) 'dart:html';
+`;
+
+        const imports = ImportUtils.findAllImports(raw);
+
+        expect(imports.length).toBe(4);
+
+        // both import and comment text should be present
+        expect(imports[0].rawBody).toContain('this is a comment');
+        expect(imports[0].rawBody).toContain("import 'something.dart';");
+
+        expect(imports[1].rawBody).toContain('this is a comment, too!');
+        expect(imports[1].rawBody).toContain("import 'something.dart' as something_else;");
+
+        expect(imports[2].rawBody).toContain('This is a conditional import!');
+        expect(imports[2].rawBody).toContain(
+            "import 'dart.math' if (dart.library.html) 'dart:html';"
+        );
+
+        expect(imports[3].rawBody).toContain('this is also a conditional import!');
+        expect(imports[3].rawBody).toContain(
+            "import 'dart.math' if (dart.library.html) 'dart:html';"
+        );
+    });
+
+    test('should detect multiline conditional imports with basic imports with no blank lines', () => {
+        const raw = `
+// this is a comment
+import 'something.dart';
+import 'dart:math'
+    if (dart.library.html) 'dart:html'
+    if (dart.library.io) 'dart:io';
+`;
+
+        const imports = ImportUtils.findAllImports(raw);
+
+        expect(imports.length).toBe(2);
+
+        // both import and comment text should be present
+        expect(imports[0].rawBody).toContain('this is a comment');
+        expect(imports[0].rawBody).toContain("import 'something.dart';");
+
+        expect(imports[1].rawBody).toContain(
+            `import 'dart:math'
+    if (dart.library.html) 'dart:html'
+    if (dart.library.io) 'dart:io';`
+        );
+    });
+
+    test('should detect multiline conditional imports with basic imports with blank lines', () => {
+        const raw = `
+// this is a comment
+import 'something.dart';
+
+import 'dart:math'
+    if (dart.library.html) 'dart:html'
+    if (dart.library.io) 'dart:io';
+`;
+
+        const imports = ImportUtils.findAllImports(raw);
+
+        expect(imports.length).toBe(2);
+
+        // both import and comment text should be present
+        expect(imports[0].rawBody).toContain('this is a comment');
+        expect(imports[0].rawBody).toContain("import 'something.dart';");
+
+        expect(imports[1].rawBody).toContain(
+            `import 'dart:math'
+    if (dart.library.html) 'dart:html'
+    if (dart.library.io) 'dart:io';`
+        );
+    });
+
+    test('should detect multiline conditional imports with comments mixed with basic imports', () => {
+        const raw = `
+// this is a comment
+import 'something.dart';
+
+// this is a conditional import
+import 'dart:math'
+    // we import this sometimes
+    if (dart.library.html) 'dart:html'
+
+    // but other times we import this
+    if (dart.library.io) 'dart:io';
+`;
+
+        const imports = ImportUtils.findAllImports(raw);
+
+        expect(imports.length).toBe(2);
+
+        // both import and comment text should be present
+        expect(imports[0].rawBody).toContain('this is a comment');
+        expect(imports[0].rawBody).toContain("import 'something.dart';");
+
+        expect(imports[1].rawBody).toContain('// this is a conditional import\n');
+        expect(imports[1].rawBody).toContain("import 'dart:math'\n");
+        expect(imports[1].rawBody).toContain('  // we import this sometimes\n');
+        expect(imports[1].rawBody).toContain("  if (dart.library.html) 'dart:html'\n");
+        expect(imports[1].rawBody).toContain('  // but other times we import this\n');
+        expect(imports[1].rawBody).toContain("  if (dart.library.io) 'dart:io';");
+    });
+
+    test('should detect multiline conditional imports with comments mixed with basic imports with many blank lines', () => {
+        const raw = `
+// this is a comment
+import 'something.dart';
+
+// this is a conditional import
+import 'dart:math'
+
+
+    // we import this sometimes
+    if (dart.library.html) 'dart:html'
+
+
+
+    // but other times we import this
+    if (dart.library.io) 'dart:io';
+`;
+
+        const imports = ImportUtils.findAllImports(raw);
+
+        expect(imports.length).toBe(2);
+
+        // both import and comment text should be present
+        expect(imports[0].rawBody).toContain('this is a comment');
+        expect(imports[0].rawBody).toContain("import 'something.dart';");
+
+        expect(imports[1].rawBody).toContain('// this is a conditional import\n');
+        expect(imports[1].rawBody).toContain("import 'dart:math'\n");
+        expect(imports[1].rawBody).toContain('  // we import this sometimes\n');
+        expect(imports[1].rawBody).toContain("  if (dart.library.html) 'dart:html'\n");
+        expect(imports[1].rawBody).toContain('  // but other times we import this\n');
+        expect(imports[1].rawBody).toContain("  if (dart.library.io) 'dart:io';");
+    });
+
+    test('should detect multiline conditional imports with comments mixed with basic imports with many trailing blank lines', () => {
+        const raw = `
+// this is a comment
+import 'something.dart';
+
+// this is a conditional import
+import 'dart:math'
+    // we import this sometimes
+    if (dart.library.html) 'dart:html'
+
+    // but other times we import this
+    if (dart.library.io) 'dart:io';
+
+
+
+
+
+
+
+    `;
+
+        const imports = ImportUtils.findAllImports(raw);
+
+        expect(imports.length).toBe(2);
+
+        // both import and comment text should be present
+        expect(imports[0].rawBody).toContain('this is a comment');
+        expect(imports[0].rawBody).toContain("import 'something.dart';");
+
+        expect(imports[1].rawBody).toContain('// this is a conditional import\n');
+        expect(imports[1].rawBody).toContain("import 'dart:math'\n");
+        expect(imports[1].rawBody).toContain('  // we import this sometimes\n');
+        expect(imports[1].rawBody).toContain("  if (dart.library.html) 'dart:html'\n");
+        expect(imports[1].rawBody).toContain('  // but other times we import this\n');
+        expect(imports[1].rawBody).toContain("  if (dart.library.io) 'dart:io';");
+    });
+
+    test('should simplify a multiline import statement into a single line', () => {
+        const raw = `
+import 'foo.dart'
+    if (dart.library.io) 'src/hw_io.dart'
+    if (dart.library.html) 'src/hw_html.dart';
+`;
+
+        const simplifiedImport = ImportUtils.simplifyMultilineImport(raw);
+        const expected = `import 'foo.dart' if (dart.library.io) 'src/hw_io.dart' if (dart.library.html) 'src/hw_html.dart';`;
+
+        expect(simplifiedImport).toBe(expected);
+    });
+
+    test('should simplify a multiline import statement with comments into a single line', () => {
+        const raw = `
+// this is a comment
+import 'foo.dart'
+    // this is a comment, too!
+    if (dart.library.io) 'src/hw_io.dart'
+
+    // this is also a comment
+    if (dart.library.html) 'src/hw_html.dart';
+`;
+
+        const simplifiedImport = ImportUtils.simplifyMultilineImport(raw);
+        const expected = `import 'foo.dart' if (dart.library.io) 'src/hw_io.dart' if (dart.library.html) 'src/hw_html.dart';`;
+
+        expect(simplifiedImport).toBe(expected);
+    });
+
+    test('should correctly find all import statements from a raw string', () => {
+        const raw = `
+import 'something';
+import 'something' as something_else;
+import 'something/with/a/long/path';
+import '';
+import 'as' as a_s;
+
+// multiline imports
+import 'foo.dart'
+    if (dart.library.io) 'src/hw_io.dart'
+    if (dart.library.html) 'src/hw_html.dart';
+
+import 'bar.dart'
+    if (dart.library.html) 'package:eam_flutter/form/webui.dart'
+    as multiPlatform;   
+
+// this is a comment
+import 'baz.dart';
+
+@deprecated
+import 'qux.dart';
+
+// this is deprecated
+@deprecated
+import 'quux.dart';
+`;
+
+        const imports = ImportUtils.findAllImports(raw);
+
+        expect(imports.length).toBe(10);
+
+        // both import and comment text should be present (if applicable)
+        expect(imports[0].rawBody).toContain("import 'something';");
+        expect(imports[1].rawBody).toContain("import 'something' as something_else;");
+        expect(imports[2].rawBody).toContain("import 'something/with/a/long/path';");
+        expect(imports[3].rawBody).toContain("import '';");
+        expect(imports[4].rawBody).toContain("import 'as' as a_s;");
+
+        expect(imports[5].rawBody).toContain("import 'foo.dart'");
+        expect(imports[5].rawBody).toContain("if (dart.library.io) 'src/hw_io.dart'");
+        expect(imports[5].rawBody).toContain("if (dart.library.html) 'src/hw_html.dart';");
+
+        expect(imports[6].rawBody).toContain("import 'bar.dart'");
+        expect(imports[6].rawBody).toContain(
+            "if (dart.library.html) 'package:eam_flutter/form/webui.dart'"
+        );
+        expect(imports[6].rawBody).toContain('as multiPlatform;');
+
+        expect(imports[7].rawBody).toContain('// this is a comment');
+        expect(imports[7].rawBody).toContain("import 'baz.dart';");
+
+        expect(imports[8].rawBody).toContain('@deprecated');
+        expect(imports[8].rawBody).toContain("import 'qux.dart';");
+
+        expect(imports[9].rawBody).toContain('// this is deprecated');
+        expect(imports[9].rawBody).toContain('@deprecated');
+        expect(imports[9].rawBody).toContain("import 'quux.dart';");
+    });
+
     test('should get only path section of an import', () => {
-        const imports = [
-            `import 'something';`,
-            `import 'something' as something_else;`,
-            `import 'something/with/a/long/path';`,
-            `import '';`,
-            `import 'as' as a_s;`,
-        ];
+        const imports = {
+            "import 'something';": 'something',
+            "import 'something' as something_else;": 'something',
+            "import 'something/with/a/long/path';": 'something/with/a/long/path',
+            "import '';": '',
+            "import 'as' as a_s;": 'as',
+            "import 'as' show a_s;": 'as',
 
-        const importPaths = [`something`, `something`, `something/with/a/long/path`, ``, `as`];
+            // multiline imports
+            "import 'foo.dart'\n    if (dart.library.io) 'src/hw_io.dart'\n    if (dart.library.html) 'src/hw_html.dart';":
+                'foo.dart',
 
-        imports.forEach((statement, i) => {
-            expect(ImportUtils.getImportPath(statement)).toBe(importPaths[i]);
+            // import with a comment
+            "// This imports foo\nimport 'foo.dart';": 'foo.dart',
+
+            // annotated import
+            "// @deprecated\nimport 'foo.dart';": 'foo.dart',
+
+            // import with a commented import before it
+            "// import 'not_this_one.dart'\nimport 'foo.dart';": 'foo.dart',
+        } as any;
+
+        Object.keys(imports).forEach((raw) => {
+            const importStatement = new ImportStatement(raw, 0);
+            expect(importStatement.path).toBe(imports[raw]);
         });
     });
 
     test('should sort imports alphabetically', () => {
         const imports = [
-            `import 'csomething/with/a/long/path';`,
-            `import 'eas' as a_s;`,
-            `import 'd';`,
-            `import 'asomething';`,
-            `import 'bsomething' as something_else;`,
+            new ImportStatement(`import 'csomething/with/a/long/path';`, 0),
+            new ImportStatement(`import 'eas' as a_s;`, 0),
+            new ImportStatement(`import 'd';`, 0),
+            new ImportStatement(`import 'asomething';`, 0),
+            new ImportStatement(`import 'bsomething' as something_else;`, 0),
         ];
 
         const sortedImports = [
-            `import 'asomething';`,
-            `import 'bsomething' as something_else;`,
-            `import 'csomething/with/a/long/path';`,
-            `import 'd';`,
-            `import 'eas' as a_s;`,
+            new ImportStatement(`import 'asomething';`, 0),
+            new ImportStatement(`import 'bsomething' as something_else;`, 0),
+            new ImportStatement(`import 'csomething/with/a/long/path';`, 0),
+            new ImportStatement(`import 'd';`, 0),
+            new ImportStatement(`import 'eas' as a_s;`, 0),
         ];
 
         expect(ImportUtils.sortAlphabetically(imports)).toStrictEqual(sortedImports);

--- a/src/app/import-utils/import-utils.ts
+++ b/src/app/import-utils/import-utils.ts
@@ -1,38 +1,77 @@
+import { ImportStatement } from '../types/import-statement.model';
 import { StatementGroup } from '../types/statement-group';
 
 export class ImportUtils {
-    static indexOfFirstImport(imports: string[]): number {
-        return imports.findIndex((statement) => this.isImportStatement(statement));
+    static lineNumberOfFirstImport(imports: ImportStatement[]): number {
+        return imports
+            .map((statement) => statement.lineNumber)
+            .reduce((min, current) => (current < min ? current : min), Number.MAX_SAFE_INTEGER);
     }
 
-    static indexOfLastImport(imports: string[]): number {
-        // reversing to find last item that matches
-        const reversedLastIndex = imports
-            .reverse()
-            .findIndex((statement) => this.isImportStatement(statement))!;
-
-        if (reversedLastIndex === -1) {
-            return 0;
-        }
-
-        // to get real index
-        return imports.length - reversedLastIndex;
+    static lineNumberOfLastImport(imports: ImportStatement[]): number {
+        return imports
+            .map((statement) => statement.lineNumber)
+            .reduce((max, current) => (current > max ? current : max), Number.MIN_SAFE_INTEGER);
     }
 
     static isImportStatement(statement: string): boolean {
         // note: all these import statements probably have '\n' at the end, so use 'm' flag for multiline detection
-        return RegExp(/^import.*;$/, 'gm').test(statement);
+        return RegExp(/^import\s+[\s\S]*?;\s*$/, 'gm').test(statement);
     }
 
-    static extractFormattedImports(document: string): string[] {
-        return document
-            .split('\n')
-            .filter((line) => this.isImportStatement(line))
-            .map((line) => line.trim());
+    static findAllImports(document: string): ImportStatement[] {
+        const lines = document.split('\n');
+
+        let currentImport: ImportStatement | undefined;
+        const imports: ImportStatement[] = [];
+
+        lines.forEach((line, index) => {
+            const lineNumber = index + 1;
+
+            // line is import
+            if (this.isImportStatement(line)) {
+                if (!currentImport) {
+                    currentImport = new ImportStatement(line, lineNumber);
+                } else {
+                    currentImport.rawBody += '\n' + line;
+                }
+
+                imports.push(currentImport);
+                currentImport = undefined;
+                return;
+            }
+
+            // line is not empty, but not an import
+            if (line.trim() !== '') {
+                if (!currentImport) {
+                    currentImport = new ImportStatement(line, lineNumber);
+                } else {
+                    currentImport.rawBody += '\n' + line;
+                }
+
+                return;
+            }
+
+            // line is empty
+            if (line.trim() === '') {
+                // if current import is a valid import, add it to the list
+                if (
+                    currentImport &&
+                    this.isImportStatement(this.simplifyMultilineImport(currentImport.rawBody))
+                ) {
+                    imports.push(currentImport);
+                    currentImport = undefined;
+                }
+            }
+        });
+
+        return imports;
     }
 
-    static sortAlphabetically(imports: string[]): string[] {
-        return imports.sort();
+    static sortAlphabetically(imports: ImportStatement[]): ImportStatement[] {
+        return imports.sort((a, b) => {
+            return a.path < b.path ? -1 : a.path > b.path ? 1 : 0;
+        });
     }
 
     /**
@@ -50,6 +89,7 @@ export class ImportUtils {
      * ```
      * */
     static getImportPath(statement: string) {
+        // TODO: convert to using regex to extract path to support multiline imports
         return statement
             .trim()
             .replace(/'/g, '')
@@ -62,5 +102,23 @@ export class ImportUtils {
 
     static removeEmptyGroups(groups: StatementGroup[]): StatementGroup[] {
         return groups.filter((group) => group.imports.length > 0);
+    }
+
+    static simplifyMultilineImport(statement: string): string {
+        let formattedStatement = statement.trim();
+
+        // first remove comments
+        formattedStatement = formattedStatement.replace(/\/\/.*$/gm, '');
+
+        // then remove tabs
+        formattedStatement = formattedStatement.replace(/\t/g, '');
+
+        // then remove newlines
+        formattedStatement = formattedStatement.replace(/\n/g, '');
+
+        // then remove multiple spaces
+        formattedStatement = formattedStatement.replace(/\s{2,}/g, ' ');
+
+        return formattedStatement;
     }
 }

--- a/src/app/import-utils/import-utils.ts
+++ b/src/app/import-utils/import-utils.ts
@@ -34,6 +34,13 @@ export class ImportUtils {
                     currentImport = new ImportStatement(line, lineNumber);
                 } else {
                     currentImport.rawBody += '\n' + line;
+
+                    // incrementing only when not first import, because first
+                    // import's first line number is important (compared to the
+                    // last import, in which only the last line number matters)
+                    if (imports.length > 0) {
+                        currentImport.lineNumber += 1;
+                    }
                 }
 
                 imports.push(currentImport);
@@ -47,6 +54,13 @@ export class ImportUtils {
                     currentImport = new ImportStatement(line, lineNumber);
                 } else {
                     currentImport.rawBody += '\n' + line;
+
+                    // incrementing only when not first import, because first
+                    // import's first line number is important (compared to the
+                    // last import, in which only the last line number matters)
+                    if (imports.length > 0) {
+                        currentImport.lineNumber += 1;
+                    }
                 }
 
                 return;

--- a/src/app/main.ts
+++ b/src/app/main.ts
@@ -61,7 +61,7 @@ export class App {
     }
 
     private sortImports(document: vscode.TextDocument): { sortedImports: string; range: Range } {
-        const sortingResult = this.importSorter!.sortImports(document.getText());
+        const sortingResult = this.importSorter.sortImports(document.getText());
 
         return {
             sortedImports: sortingResult.sortedImports,
@@ -73,6 +73,7 @@ export class App {
     }
 
     private replaceWithSortedImports(sortedImports: string, range: Range) {
-        this.fileInteractor.replace('', range.start, range.end, sortedImports);
+        // replacing a range seems to be non-inclusive of the start index, so we need to subtract 1
+        this.fileInteractor.replace('', range.start - 1, range.end, sortedImports);
     }
 }

--- a/src/app/types/import-statement.model.ts
+++ b/src/app/types/import-statement.model.ts
@@ -1,0 +1,13 @@
+export class ImportStatement {
+    constructor(public rawBody: string, public lineNumber: number) {}
+
+    get path(): string {
+        // first remove all comments
+        const noComments = this.rawBody.replace(/\/\/.*$/gm, '');
+
+        // find whatever's between single or double quotes after the first import keyword
+        const match = noComments.match(/import\s+['"]([^'"]+)['"]/);
+
+        return match ? match[1] : '';
+    }
+}

--- a/src/app/types/statement-group.ts
+++ b/src/app/types/statement-group.ts
@@ -1,5 +1,7 @@
+import { ImportStatement } from './import-statement.model';
+
 export type StatementGroup = {
     groupRegex: RegExp;
-    imports: string[];
+    imports: ImportStatement[];
 	order: number;
 };


### PR DESCRIPTION
# Changes:
Wrote new algorithm for finding and parsing imports. Now supports comments, annotations, multi-line conditional imports, and a combination of all the of the aforementioned.