### PR TITLE
Fix duplicating issue when running sort on one import statement

### DIFF
--- a/src/app/import-sorter/import-sorter.impl.test.ts
+++ b/src/app/import-sorter/import-sorter.impl.test.ts
@@ -129,7 +129,7 @@ const DEFAULT_SETTINGS: IExtensionSettings = {
     projectName: '',
 };
 
-describe('', () => {
+describe('Import Sorter', () => {
     let importSorter: IImportSorter;
     let settings: IExtensionSettings;
 
@@ -718,7 +718,44 @@ import 'viewmodel.dart';`;
         expect(sortingResult2.sortedImports).toBe(expectedSortedImports);
     });
 
-    test('Return no result when there are no imports to sort', () => {
+    test('Sorts a list of imports, starting with an empty line followed by a basic import with a comment and a multiline conditional import', () => {
+        const messyImports = `// this is a comment
+import 'something.dart';
+
+// this is a conditional import
+import 'dart:math'
+
+
+    // we import this sometimes
+    if (dart.library.html) 'dart:html'
+
+
+
+    // but other times we import this
+    if (dart.library.io) 'dart:io';`;
+
+        const expectedSortedImports = `// this is a conditional import
+import 'dart:math'
+    // we import this sometimes
+    if (dart.library.html) 'dart:html'
+    // but other times we import this
+    if (dart.library.io) 'dart:io';
+// this is a comment
+import 'something.dart';`;
+
+        const sortingResult = importSorter.sortImports(messyImports);
+        expect(sortingResult.firstRawImportIndex).toBe(1);
+        expect(sortingResult.lastRawImportIndex).toBe(14);
+        expect(sortingResult.sortedImports).toBe(expectedSortedImports);
+
+        // Sorting again should not change anything
+        const sortingResult2 = importSorter.sortImports(sortingResult.sortedImports);
+        expect(sortingResult2.firstRawImportIndex).toBe(1);
+        expect(sortingResult2.lastRawImportIndex).toBe(8);
+        expect(sortingResult2.sortedImports).toBe(expectedSortedImports);
+    });
+
+    test('Returns no result when there are no imports to sort', () => {
         const sortingResult = importSorter.sortImports('');
 
         expect(sortingResult.firstRawImportIndex).toBe(-1);
@@ -726,30 +763,66 @@ import 'viewmodel.dart';`;
         expect(sortingResult.sortedImports).toBe('');
     });
 
-    test('Sorts a list of imports with a library statement at the beginning', () => {
-        const messyImports = `library solid_repositories;
+    test('Does not sort when there is a single import statement', () => {
+        const messyImports = `// This is a comment
+// It's multiline
 
 import 'package:flutter/foundation.dart';
         
 part 'i_authentication_repository.dart';`;
 
-        const expectedSortedImports = `library solid_repositories;
-
-import 'package:flutter/foundation.dart';
-        
-part 'i_authentication_repository.dart';`;
+        const expectedSortedImports = ``;
 
         const sortingResult = importSorter.sortImports(messyImports);
 
-        expect(sortingResult.firstRawImportIndex).toBe(2);
-        expect(sortingResult.lastRawImportIndex).toBe(3);
+        expect(sortingResult.firstRawImportIndex).toBe(-1);
+        expect(sortingResult.lastRawImportIndex).toBe(-1);
         expect(sortingResult.sortedImports).toBe(expectedSortedImports);
 
         // Sorting again should not change anything
         const sortingResult2 = importSorter.sortImports(sortingResult.sortedImports);
 
-        expect(sortingResult2.firstRawImportIndex).toBe(2);
-        expect(sortingResult2.lastRawImportIndex).toBe(3);
+        expect(sortingResult2.firstRawImportIndex).toBe(-1);
+        expect(sortingResult2.lastRawImportIndex).toBe(-1);
+        expect(sortingResult2.sortedImports).toBe(expectedSortedImports);
+    });
+
+    test('Does not sort when there is only a single import statement', () => {
+        const messyImports = `import 'package:flutter/foundation.dart';`;
+
+        const expectedSortedImports = ``;
+
+        const sortingResult = importSorter.sortImports(messyImports);
+
+        expect(sortingResult.firstRawImportIndex).toBe(-1);
+        expect(sortingResult.lastRawImportIndex).toBe(-1);
+        expect(sortingResult.sortedImports).toBe(expectedSortedImports);
+
+        // Sorting again should not change anything
+        const sortingResult2 = importSorter.sortImports(sortingResult.sortedImports);
+
+        expect(sortingResult2.firstRawImportIndex).toBe(-1);
+        expect(sortingResult2.lastRawImportIndex).toBe(-1);
+        expect(sortingResult2.sortedImports).toBe(expectedSortedImports);
+    });
+
+    test('Does not sort when there is a single import with a comment', () => {
+        const messyImports = `// This is a comment
+import 'package:flutter/foundation.dart';`;
+
+        const expectedSortedImports = ``;
+
+        const sortingResult = importSorter.sortImports(messyImports);
+
+        expect(sortingResult.firstRawImportIndex).toBe(-1);
+        expect(sortingResult.lastRawImportIndex).toBe(-1);
+        expect(sortingResult.sortedImports).toBe(expectedSortedImports);
+
+        // Sorting again should not change anything
+        const sortingResult2 = importSorter.sortImports(sortingResult.sortedImports);
+
+        expect(sortingResult2.firstRawImportIndex).toBe(-1);
+        expect(sortingResult2.lastRawImportIndex).toBe(-1);
         expect(sortingResult2.sortedImports).toBe(expectedSortedImports);
     });
 });

--- a/src/app/import-sorter/import-sorter.impl.test.ts
+++ b/src/app/import-sorter/import-sorter.impl.test.ts
@@ -725,4 +725,31 @@ import 'viewmodel.dart';`;
         expect(sortingResult.lastRawImportIndex).toBe(-1);
         expect(sortingResult.sortedImports).toBe('');
     });
+
+    test('Sorts a list of imports with a library statement at the beginning', () => {
+        const messyImports = `library solid_repositories;
+
+import 'package:flutter/foundation.dart';
+        
+part 'i_authentication_repository.dart';`;
+
+        const expectedSortedImports = `library solid_repositories;
+
+import 'package:flutter/foundation.dart';
+        
+part 'i_authentication_repository.dart';`;
+
+        const sortingResult = importSorter.sortImports(messyImports);
+
+        expect(sortingResult.firstRawImportIndex).toBe(2);
+        expect(sortingResult.lastRawImportIndex).toBe(3);
+        expect(sortingResult.sortedImports).toBe(expectedSortedImports);
+
+        // Sorting again should not change anything
+        const sortingResult2 = importSorter.sortImports(sortingResult.sortedImports);
+
+        expect(sortingResult2.firstRawImportIndex).toBe(2);
+        expect(sortingResult2.lastRawImportIndex).toBe(3);
+        expect(sortingResult2.sortedImports).toBe(expectedSortedImports);
+    });
 });

--- a/src/app/import-sorter/import-sorter.impl.ts
+++ b/src/app/import-sorter/import-sorter.impl.ts
@@ -18,7 +18,8 @@ export class ImportSorter implements IImportSorter {
     sortImports(rawDocumentBody: string): SortingResult {
         const strippedImports = ImportUtils.findAllImports(rawDocumentBody);
 
-        if (strippedImports.length === 0) {
+        // if none or only one statement, don't sort
+        if (strippedImports.length === 0 || strippedImports.length === 1) {
             return { sortedImports: '', firstRawImportIndex: -1, lastRawImportIndex: -1 }; // nothing to sort
         }
 


### PR DESCRIPTION
# Description

Sorting when only a single import statement is detected would cause that statement to be duplicated. This is due to how the line number for import statements is calculated.

This PR fixes that.

---
### Previously:
```dart
// this is an import
import 'something.dart';
```

would become this after sorting:
```dart
// this is an import
import 'something.dart';
import 'something.dart';	// <- Duplicated!
```

### Now:
Sorting doesn't even run when only one import statement is detected.

Solves #53 